### PR TITLE
add azure pat as param to allow for azure devops private nuget feeds

### DIFF
--- a/clio/Command/InstallNugetPackageCommand.cs
+++ b/clio/Command/InstallNugetPackageCommand.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Clio.Common;
+using Clio.Package.NuGet;
 using Clio.Project.NuGet;
 using CommandLine;
 
@@ -23,6 +24,12 @@ namespace Clio.Command
 			Default = "https://www.nuget.org/api/v2")]
 		public string SourceUrl { get; set; }
 
+		[Option("AzurePAT", Required = false, HelpText = "Azure DevOps PAT for private Artifacts NuGet Feed")]
+		public string PersonalAccessToken
+		{
+			get => AzurePAT.PAT;
+			set => AzurePAT.PAT = value;
+		}
 		#endregion
 
 	}

--- a/clio/Package/NuGet/AzurePAT.cs
+++ b/clio/Package/NuGet/AzurePAT.cs
@@ -1,0 +1,7 @@
+﻿namespace Clio.Package.NuGet
+{
+	public static class AzurePAT
+	{
+		public static string PAT { get; set; }
+	}
+}

--- a/clio/Package/NuGet/NugetPackagesProvider.cs
+++ b/clio/Package/NuGet/NugetPackagesProvider.cs
@@ -2,11 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Clio.Common;
+using Clio.Package.NuGet;
 
 namespace Clio.Project.NuGet
 {
@@ -28,6 +31,12 @@ namespace Clio.Project.NuGet
 		private async Task<string> GetAllVersionsNugetPackagesXml(string nugetSourceUrl, string packageName) {
 			var findPackagesByIdUrl = $"{nugetSourceUrl.TrimEnd('/')}/FindPackagesById()?id='{packageName}'";
 			using var httpClient = new HttpClient();
+
+			if (!string.IsNullOrWhiteSpace(AzurePAT.PAT))
+			{
+				httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes($":{AzurePAT.PAT}")));
+			}
+
 			var response = await httpClient.GetAsync(findPackagesByIdUrl);
 			var allVersionsNugetPackagesXml = await response.Content.ReadAsStringAsync();
 			if (!response.IsSuccessStatusCode) {


### PR DESCRIPTION
* adds --AzurePAT as command line param for installng

static class is hacky but passing a new parameter through 20 methods just so that it's available at the one spot it's needed seems a bit stupid.
the better solution would probably passing the InstallNugetPkgOptions object through all the methods and grabbing the required attributes at each method. this would also make adding new parameters easier